### PR TITLE
refactor: drop broken `listAllInstances` function

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -31,7 +31,7 @@ export async function listInstance({ host, port = DEFAULT_PORT, family, signal, 
     Buffer.from(instanceName)
   ]);
 
-  const response = await sendRequest({ address: host, family }, port, false, timeout, request, signal);
+  const response = await sendRequest({ address: host, family }, port, timeout, request, signal);
   if (!response) {
     return;
   }
@@ -51,28 +51,7 @@ export async function listInstances({ host, port = DEFAULT_PORT, family, signal,
   }
 
   const request = Buffer.from([0x03]);
-  const response = await sendRequest({ address: host, family }, port, false, timeout, request, signal);
-  if (!response) {
-    return [];
-  }
-
-  return parseResponse(response);
-}
-
-export async function listAllInstances({ port = DEFAULT_PORT, family, signal, timeout = DEFAULT_TIMEOUT }: {
-  port?: number;
-  family: 4 | 6;
-  timeout?: number;
-  signal?: AbortSignal;
-}) {
-  if (signal?.aborted) {
-    throw new Error('aborted');
-  }
-
-  const address = family === 6 ? 'FF02::1' : '255.255.255.255';
-
-  const request = Buffer.from([0x02]);
-  const response = await sendRequest({ address, family }, port, true, timeout, request, signal);
+  const response = await sendRequest({ address: host, family }, port, timeout, request, signal);
   if (!response) {
     return [];
   }
@@ -91,7 +70,7 @@ function parseResponse(buffer: Buffer): Array < Instance > {
   return parse(responseString);
 }
 
-function sendRequest(address: { address: string, family: 4 | 6 }, port: number, broadcast: boolean, timeout: number, request: Buffer, signal?: AbortSignal): Promise <Buffer | undefined> {
+function sendRequest(address: { address: string, family: 4 | 6 }, port: number, timeout: number, request: Buffer, signal?: AbortSignal): Promise <Buffer | undefined> {
   const socketType = address.family === 6 ? 'udp6' : 'udp4';
   const socket = dgram.createSocket(socketType);
 
@@ -142,8 +121,6 @@ function sendRequest(address: { address: string, family: 4 | 6 }, port: number, 
 
       socket.on('error', onError);
       socket.on('message', onMessage);
-
-      socket.setBroadcast(broadcast);
 
       socket.send(request, 0, request.length, port, address.address, (err) => {
         if (err) {

--- a/test/client-test.ts
+++ b/test/client-test.ts
@@ -8,447 +8,312 @@ import { listInstance, listInstances } from '../src/index';
 import Instance from '../src/instance';
 import * as Parser from '../src/parser';
 
-describe('Client', function() {
-  (['udp4', 'udp6'] as dgram.SocketType[]).forEach(function(family) {
-    describe(`via ${family}`, function() {
-      let server: dgram.Socket;
+(['udp4', 'udp6'] as dgram.SocketType[]).forEach(function(family) {
+  describe(`via ${family}`, function() {
+    let server: dgram.Socket;
 
-      beforeEach(function(done) {
-        server = dgram.createSocket(family);
-        server.on('error', done);
-        server.bind(0, family === 'udp6' ? '::1' : '127.0.0.1', () => {
-          server.removeListener('error', done);
-          server.setBroadcast(true);
+    beforeEach(function(done) {
+      server = dgram.createSocket(family);
+      server.on('error', done);
+      server.bind(0, family === 'udp6' ? '::1' : '127.0.0.1', () => {
+        server.removeListener('error', done);
+        server.setBroadcast(true);
 
-          done();
+        done();
+      });
+    });
+
+    afterEach(function(done) {
+      server.close(done);
+    });
+
+    describe('listInstance', function() {
+      describe('with a valid response', function() {
+        beforeEach(function() {
+          server.once('message', (data, address) => {
+            const response = Buffer.concat([
+              Buffer.from([0x05, 0x58, 0x00]),
+              Buffer.from('ServerName;ILSUNG1;InstanceName;YUKONSTD;IsClustered;No;Version;9.00.1399.06;tcp;57137;;')
+            ]);
+            server.send(response, 0, response.length, address.port, address.address);
+          });
+        });
+
+        it('sends a CLNT_UCAST_INST request', async function() {
+          server.once('message', (data) => {
+            const expected = Buffer.concat([
+              Buffer.from([0x04]),
+              Buffer.from('YUKONSTD')
+            ]);
+            assert.deepEqual(data, expected);
+          });
+
+          await listInstance({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          }, 'YUKONSTD');
+        });
+
+        it('returns an Instance object', async function() {
+          let instance = await listInstance({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          }, 'YUKONSTD');
+
+          assert.instanceOf(instance, Instance);
+          instance = instance!;
+
+          assert.strictEqual(instance.serverName, 'ILSUNG1');
+          assert.strictEqual(instance.instanceName, 'YUKONSTD');
+          assert.isFalse(instance.isClustered);
+          assert.strictEqual(instance.version, '9.00.1399.06');
+          assert.strictEqual(instance.tcpPort, 57137);
         });
       });
 
-      afterEach(function(done) {
-        server.close(done);
-      });
-
-      describe('listInstance', function() {
-        describe('with a valid response', function() {
-          beforeEach(function() {
-            server.once('message', (data, address) => {
-              const response = Buffer.concat([
-                Buffer.from([0x05, 0x58, 0x00]),
-                Buffer.from('ServerName;ILSUNG1;InstanceName;YUKONSTD;IsClustered;No;Version;9.00.1399.06;tcp;57137;;')
-              ]);
-              server.send(response, 0, response.length, address.port, address.address);
-            });
+      describe('with an invalid response', function() {
+        it('raises a SyntaxError on invalid payload', async function() {
+          server.once('message', (data, address) => {
+            const response = Buffer.concat([
+              Buffer.from([0x05, 0x00, 0x40]),
+              Buffer.from('ServerName;ILSUNG1;InstanceName;YUKONSTD;ThisWillNoLongerBeValid')
+            ]);
+            server.send(response, 0, response.length, address.port, address.address);
           });
 
-          it('sends a CLNT_UCAST_INST request', async function() {
-            server.once('message', (data) => {
-              const expected = Buffer.concat([
-                Buffer.from([0x04]),
-                Buffer.from('YUKONSTD')
-              ]);
-              assert.deepEqual(data, expected);
-            });
-
-            await listInstance({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            }, 'YUKONSTD');
-          });
-
-          it('returns an Instance object', async function() {
-            let instance = await listInstance({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            }, 'YUKONSTD');
-
-            assert.instanceOf(instance, Instance);
-            instance = instance!;
-
-            assert.strictEqual(instance.serverName, 'ILSUNG1');
-            assert.strictEqual(instance.instanceName, 'YUKONSTD');
-            assert.isFalse(instance.isClustered);
-            assert.strictEqual(instance.version, '9.00.1399.06');
-            assert.strictEqual(instance.tcpPort, 57137);
-          });
+          await assert.isRejected(listInstance({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          }, 'YUKONSTD'), Parser.SyntaxError, 'Expected "IsClustered" but "T" found.');
         });
 
-        describe('with an invalid response', function() {
-          it('raises a SyntaxError on invalid payload', async function() {
-            server.once('message', (data, address) => {
-              const response = Buffer.concat([
-                Buffer.from([0x05, 0x00, 0x40]),
-                Buffer.from('ServerName;ILSUNG1;InstanceName;YUKONSTD;ThisWillNoLongerBeValid')
-              ]);
-              server.send(response, 0, response.length, address.port, address.address);
-            });
+        it('raises an Error on invalid response type', async function() {
+          server.once('message', (data, address) => {
+            const response = Buffer.from('This is a completely invalid response');
 
-            await assert.isRejected(listInstance({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            }, 'YUKONSTD'), Parser.SyntaxError, 'Expected "IsClustered" but "T" found.');
+            server.send(response, 0, response.length, address.port, address.address);
           });
 
-          it('raises an Error on invalid response type', async function() {
-            server.once('message', (data, address) => {
-              const response = Buffer.from('This is a completely invalid response');
-
-              server.send(response, 0, response.length, address.port, address.address);
-            });
-
-            await assert.isRejected(listInstance({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            }, 'YUKONSTD'), Error, 'Invalid SSRP response.');
-          });
-        });
-
-        describe('without a response', function() {
-          it('times out after the specified timeout', async function() {
-            const start = Date.now();
-
-            await listInstance({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            }, 'YUKONSTD');
-
-            const duration = Date.now() - start;
-
-            assert.isAtLeast(duration, 99);
-            assert.isAtMost(duration, 200);
-          });
-
-          it('does not return an Instance object', async function() {
-            const instance = await listInstance({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            }, 'YUKONSTD');
-
-            assert.equal(instance, undefined);
-          });
-        });
-
-        describe('when aborted via the given signal', function() {
-          it('returns before timing out', async function() {
-            const start = Date.now();
-
-            const controller = new AbortController();
-
-            setTimeout(() => {
-              controller.abort();
-            }, 50);
-
-            await assert.isRejected(listInstance({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100,
-              signal: controller.signal
-            }, 'YUKONSTD'));
-
-            const duration = Date.now() - start;
-
-            assert.isAtLeast(duration, 50);
-            assert.isAtMost(duration, 99);
-          });
+          await assert.isRejected(listInstance({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          }, 'YUKONSTD'), Error, 'Invalid SSRP response.');
         });
       });
 
-      describe('listInstances', function() {
-        describe('with a valid response', function() {
-          beforeEach(function() {
-            server.once('message', (data, address) => {
-              const response = Buffer.concat([
-                Buffer.from([0x05, 0x47, 0x01]),
-                Buffer.from('ServerName;ILSUNG1;InstanceName;YUKONSTD;IsClustered;No;Version;9.00.1399.06;tcp;57137;;ServerName;ILSUNG1;InstanceName;YUKONDEV;IsClustered;No;Version;9.00.1399.06;np;\\\\ILSUNG1\\pipe\\MSSQL$YUKONDEV\\sql\\query;;ServerName;ILSUNG1;InstanceName;MSSQLSERVER;IsClustered;No;Version;9.00.1399.06;tcp;1433;np;\\\\ILSUNG1\\pipe\\sql\\query;;')
-              ]);
-              server.send(response, 0, response.length, address.port, address.address);
-            });
-          });
+      describe('without a response', function() {
+        it('times out after the specified timeout', async function() {
+          const start = Date.now();
 
-          it('sends a CLNT_UCAST_EX request', async function() {
-            server.once('message', (data) => {
-              const expected = Buffer.from([0x03]);
-              assert.deepEqual(data, expected);
-            });
+          await listInstance({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          }, 'YUKONSTD');
 
-            await listInstances({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            });
-          });
+          const duration = Date.now() - start;
 
-          it('returns a list of Instance objects', async function() {
-            const instances = await listInstances({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            });
-
-            let instance;
-            assert.lengthOf(instances, 3);
-
-            instance = instances[0];
-            assert.strictEqual(instance.serverName, 'ILSUNG1');
-            assert.strictEqual(instance.instanceName, 'YUKONSTD');
-            assert.isFalse(instance.isClustered);
-            assert.strictEqual(instance.version, '9.00.1399.06');
-            assert.strictEqual(instance.tcpPort, 57137);
-            assert.isUndefined(instance.npPipeName);
-
-            instance = instances[1];
-            assert.strictEqual(instance.serverName, 'ILSUNG1');
-            assert.strictEqual(instance.instanceName, 'YUKONDEV');
-            assert.isFalse(instance.isClustered);
-            assert.strictEqual(instance.version, '9.00.1399.06');
-            assert.isUndefined(instance.tcpPort);
-            assert.strictEqual(instance.npPipeName, '\\\\ILSUNG1\\pipe\\MSSQL$YUKONDEV\\sql\\query');
-
-            instance = instances[2];
-            assert.strictEqual(instance.serverName, 'ILSUNG1');
-            assert.strictEqual(instance.instanceName, 'MSSQLSERVER');
-            assert.isFalse(instance.isClustered);
-            assert.strictEqual(instance.version, '9.00.1399.06');
-            assert.strictEqual(instance.tcpPort, 1433);
-            assert.strictEqual(instance.npPipeName, '\\\\ILSUNG1\\pipe\\sql\\query');
-          });
+          assert.isAtLeast(duration, 99);
+          assert.isAtMost(duration, 200);
         });
 
-        describe('with an invalid response', function() {
-          it('raises a SyntaxError on invalid payload', async function() {
-            server.once('message', (data, address) => {
-              const response = Buffer.concat([
-                Buffer.from([0x05, 0x00, 0x40]),
-                Buffer.from('ServerName;ILSUNG1;InstanceName;YUKONSTD;ThisWillNoLongerBeValid')
-              ]);
-              server.send(response, 0, response.length, address.port, address.address);
-            });
+        it('does not return an Instance object', async function() {
+          const instance = await listInstance({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          }, 'YUKONSTD');
 
-            await assert.isRejected(listInstances({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            }), Parser.SyntaxError, 'Expected "IsClustered" but "T" found.');
-          });
-
-          it('raises an Error on invalid response type', async function() {
-            server.once('message', (data, address) => {
-              const response = Buffer.from('This is a completely invalid response');
-
-              server.send(response, 0, response.length, address.port, address.address);
-            });
-
-            await assert.isRejected(listInstances({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            }), Error, 'Invalid SSRP response.');
-          });
-        });
-
-        describe('without a response', function() {
-          it('times out after the specified timeout', async function() {
-            const start = Date.now();
-
-            await listInstances({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            });
-
-            const duration = Date.now() - start;
-
-            assert.isAtLeast(duration, 99);
-            assert.isAtMost(duration, 200);
-          });
-
-          it('returns an empty list', async function() {
-            const instances = await listInstances({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100
-            });
-
-            assert.lengthOf(instances, 0);
-          });
-        });
-
-        describe('when aborted via the given signal', function() {
-          it('returns before timing out', async function() {
-            const start = Date.now();
-
-            const controller = new AbortController();
-
-            setTimeout(() => {
-              controller.abort();
-            }, 50);
-
-            await assert.isRejected(listInstances({
-              host: server.address().address,
-              family: family === 'udp6' ? 6 : 4,
-              port: server.address().port,
-              timeout: 100,
-              signal: controller.signal
-            }));
-
-            const duration = Date.now() - start;
-
-            assert.isAtLeast(duration, 50);
-            assert.isAtMost(duration, 99);
-          });
+          assert.equal(instance, undefined);
         });
       });
 
-      // describe('listAllInstances', function() {
-      //   describe.only('with a valid response', function() {
-      //     beforeEach(function() {
-      //       server.once('message', (data, address) => {
-      //         console.log('message');
+      describe('when aborted via the given signal', function() {
+        it('returns before timing out', async function() {
+          const start = Date.now();
 
-      //         const response = Buffer.concat([
-      //           Buffer.from([0x05, 0x47, 0x01]),
-      //           Buffer.from('ServerName;ILSUNG1;InstanceName;YUKONSTD;IsClustered;No;Version;9.00.1399.06;tcp;57137;;ServerName;ILSUNG1;InstanceName;YUKONDEV;IsClustered;No;Version;9.00.1399.06;np;\\\\ILSUNG1\\pipe\\MSSQL$YUKONDEV\\sql\\query;;ServerName;ILSUNG1;InstanceName;MSSQLSERVER;IsClustered;No;Version;9.00.1399.06;tcp;1433;np;\\\\ILSUNG1\\pipe\\sql\\query;;')
-      //         ]);
-      //         server.send(response, 0, response.length, address.port, address.address);
-      //       });
-      //     });
+          const controller = new AbortController();
 
-      //     it('sends a CLNT_UCAST_EX request', async function() {
-      //       const received = new Promise((resolve, reject) => {
-      //         server.once('message', (data) => {
-      //           const expected = Buffer.from([0x02]);
-      //           assert.deepEqual(data, expected);
+          setTimeout(() => {
+            controller.abort();
+          }, 50);
 
-      //           resolve();
-      //         });
-      //       });
+          await assert.isRejected(listInstance({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100,
+            signal: controller.signal
+          }, 'YUKONSTD'));
 
-      //       await listAllInstances({
-      //         family: family === 'udp6' ? 6 : 4,
-      //         port: server.address().port,
-      //         timeout: 100
-      //       });
+          const duration = Date.now() - start;
 
-      //       await received;
-      //     });
+          assert.isAtLeast(duration, 50);
+          assert.isAtMost(duration, 99);
+        });
+      });
+    });
 
-      //     it('returns a list of Instance objects', async function() {
-      //       const instances = await listAllInstances({
-      //         family: family === 'udp6' ? 6 : 4,
-      //         port: server.address().port,
-      //         timeout: 100
-      //       });
+    describe('listInstances', function() {
+      describe('with a valid response', function() {
+        beforeEach(function() {
+          server.once('message', (data, address) => {
+            const response = Buffer.concat([
+              Buffer.from([0x05, 0x47, 0x01]),
+              Buffer.from('ServerName;ILSUNG1;InstanceName;YUKONSTD;IsClustered;No;Version;9.00.1399.06;tcp;57137;;ServerName;ILSUNG1;InstanceName;YUKONDEV;IsClustered;No;Version;9.00.1399.06;np;\\\\ILSUNG1\\pipe\\MSSQL$YUKONDEV\\sql\\query;;ServerName;ILSUNG1;InstanceName;MSSQLSERVER;IsClustered;No;Version;9.00.1399.06;tcp;1433;np;\\\\ILSUNG1\\pipe\\sql\\query;;')
+            ]);
+            server.send(response, 0, response.length, address.port, address.address);
+          });
+        });
 
-      //       let instance;
-      //       assert.lengthOf(instances, 3);
+        it('sends a CLNT_UCAST_EX request', async function() {
+          server.once('message', (data) => {
+            const expected = Buffer.from([0x03]);
+            assert.deepEqual(data, expected);
+          });
 
-      //       instance = instances[0];
-      //       assert.strictEqual(instance.serverName, 'ILSUNG1');
-      //       assert.strictEqual(instance.instanceName, 'YUKONSTD');
-      //       assert.isFalse(instance.isClustered);
-      //       assert.strictEqual(instance.version, '9.00.1399.06');
-      //       assert.strictEqual(instance.tcpPort, 57137);
-      //       assert.isUndefined(instance.npPipeName);
+          await listInstances({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          });
+        });
 
-      //       instance = instances[1];
-      //       assert.strictEqual(instance.serverName, 'ILSUNG1');
-      //       assert.strictEqual(instance.instanceName, 'YUKONDEV');
-      //       assert.isFalse(instance.isClustered);
-      //       assert.strictEqual(instance.version, '9.00.1399.06');
-      //       assert.isUndefined(instance.tcpPort);
-      //       assert.strictEqual(instance.npPipeName, '\\\\ILSUNG1\\pipe\\MSSQL$YUKONDEV\\sql\\query');
+        it('returns a list of Instance objects', async function() {
+          const instances = await listInstances({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          });
 
-      //       instance = instances[2];
-      //       assert.strictEqual(instance.serverName, 'ILSUNG1');
-      //       assert.strictEqual(instance.instanceName, 'MSSQLSERVER');
-      //       assert.isFalse(instance.isClustered);
-      //       assert.strictEqual(instance.version, '9.00.1399.06');
-      //       assert.strictEqual(instance.tcpPort, 1433);
-      //       assert.strictEqual(instance.npPipeName, '\\\\ILSUNG1\\pipe\\sql\\query');
-      //     });
-      //   });
+          let instance;
+          assert.lengthOf(instances, 3);
 
-      //   describe('with an invalid response', function() {
-      //     it('raises a SyntaxError on invalid payload', async function() {
-      //       server.once('message', (data, address) => {
-      //         const response = Buffer.concat([
-      //           Buffer.from([0x05, 0x00, 0x40]),
-      //           Buffer.from('ServerName;ILSUNG1;InstanceName;YUKONSTD;ThisWillNoLongerBeValid')
-      //         ]);
-      //         server.send(response, 0, response.length, address.port, address.address);
-      //       });
+          instance = instances[0];
+          assert.strictEqual(instance.serverName, 'ILSUNG1');
+          assert.strictEqual(instance.instanceName, 'YUKONSTD');
+          assert.isFalse(instance.isClustered);
+          assert.strictEqual(instance.version, '9.00.1399.06');
+          assert.strictEqual(instance.tcpPort, 57137);
+          assert.isUndefined(instance.npPipeName);
 
-      //       await assert.isRejected(listInstances({
-      //         host: server.address().address,
-      //         family: family === 'udp6' ? 6 : 4,
-      //         port: server.address().port,
-      //         timeout: 100
-      //       }), Parser.SyntaxError, 'Expected "IsClustered" but "T" found.');
-      //     });
+          instance = instances[1];
+          assert.strictEqual(instance.serverName, 'ILSUNG1');
+          assert.strictEqual(instance.instanceName, 'YUKONDEV');
+          assert.isFalse(instance.isClustered);
+          assert.strictEqual(instance.version, '9.00.1399.06');
+          assert.isUndefined(instance.tcpPort);
+          assert.strictEqual(instance.npPipeName, '\\\\ILSUNG1\\pipe\\MSSQL$YUKONDEV\\sql\\query');
 
-      //     it('raises an Error on invalid response type', async function() {
-      //       server.once('message', (data, address) => {
-      //         const response = Buffer.from('This is a completely invalid response');
+          instance = instances[2];
+          assert.strictEqual(instance.serverName, 'ILSUNG1');
+          assert.strictEqual(instance.instanceName, 'MSSQLSERVER');
+          assert.isFalse(instance.isClustered);
+          assert.strictEqual(instance.version, '9.00.1399.06');
+          assert.strictEqual(instance.tcpPort, 1433);
+          assert.strictEqual(instance.npPipeName, '\\\\ILSUNG1\\pipe\\sql\\query');
+        });
+      });
 
-      //         server.send(response, 0, response.length, address.port, address.address);
-      //       });
+      describe('with an invalid response', function() {
+        it('raises a SyntaxError on invalid payload', async function() {
+          server.once('message', (data, address) => {
+            const response = Buffer.concat([
+              Buffer.from([0x05, 0x00, 0x40]),
+              Buffer.from('ServerName;ILSUNG1;InstanceName;YUKONSTD;ThisWillNoLongerBeValid')
+            ]);
+            server.send(response, 0, response.length, address.port, address.address);
+          });
 
-      //       await assert.isRejected(listInstances({
-      //         host: server.address().address,
-      //         family: family === 'udp6' ? 6 : 4,
-      //         port: server.address().port,
-      //         timeout: 100
-      //       }), Error, 'Invalid SSRP response.');
-      //     });
-      //   });
+          await assert.isRejected(listInstances({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          }), Parser.SyntaxError, 'Expected "IsClustered" but "T" found.');
+        });
 
-      //   describe('without a response', async function() {
-      //     it('times out after the specified timeout', async function() {
-      //       const start = Date.now();
+        it('raises an Error on invalid response type', async function() {
+          server.once('message', (data, address) => {
+            const response = Buffer.from('This is a completely invalid response');
 
-      //       await listInstances({
-      //         host: server.address().address,
-      //         family: family === 'udp6' ? 6 : 4,
-      //         port: server.address().port,
-      //         timeout: 100
-      //       });
+            server.send(response, 0, response.length, address.port, address.address);
+          });
 
-      //       const duration = Date.now() - start;
+          await assert.isRejected(listInstances({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          }), Error, 'Invalid SSRP response.');
+        });
+      });
 
-      //       assert.isAtLeast(duration, 100);
-      //       assert.isAtMost(duration, 100 + 100);
-      //     });
+      describe('without a response', function() {
+        it('times out after the specified timeout', async function() {
+          const start = Date.now();
 
-      //     it('returns an empty list', async function() {
-      //       const instances = await listInstances({
-      //         host: server.address().address,
-      //         family: family === 'udp6' ? 6 : 4,
-      //         port: server.address().port,
-      //         timeout: 100
-      //       });
+          await listInstances({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          });
 
-      //       assert.lengthOf(instances, 0);
-      //     });
-      //   });
-      // });
+          const duration = Date.now() - start;
+
+          assert.isAtLeast(duration, 99);
+          assert.isAtMost(duration, 200);
+        });
+
+        it('returns an empty list', async function() {
+          const instances = await listInstances({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100
+          });
+
+          assert.lengthOf(instances, 0);
+        });
+      });
+
+      describe('when aborted via the given signal', function() {
+        it('returns before timing out', async function() {
+          const start = Date.now();
+
+          const controller = new AbortController();
+
+          setTimeout(() => {
+            controller.abort();
+          }, 50);
+
+          await assert.isRejected(listInstances({
+            host: server.address().address,
+            family: family === 'udp6' ? 6 : 4,
+            port: server.address().port,
+            timeout: 100,
+            signal: controller.signal
+          }));
+
+          const duration = Date.now() - start;
+
+          assert.isAtLeast(duration, 50);
+          assert.isAtMost(duration, 99);
+        });
+      });
     });
   });
 });

--- a/test/client-test.ts
+++ b/test/client-test.ts
@@ -158,7 +158,7 @@ import * as Parser from '../src/parser';
 
           const duration = Date.now() - start;
 
-          assert.isAtLeast(duration, 50);
+          assert.isAtLeast(duration, 49);
           assert.isAtMost(duration, 99);
         });
       });
@@ -310,7 +310,7 @@ import * as Parser from '../src/parser';
 
           const duration = Date.now() - start;
 
-          assert.isAtLeast(duration, 50);
+          assert.isAtLeast(duration, 49);
           assert.isAtMost(duration, 99);
         });
       });


### PR DESCRIPTION
This function was not working correctly for UDPv6, and I don't have any use for it.

BREAKING CHANGE: This changes the public API.